### PR TITLE
infra: add Dockerfile and docker-compose setup for containerized dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Dockerfile
+
+FROM python:3.13-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    postgresql-client \
+    curl \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install poetry
+ENV POETRY_HOME="/opt/poetry"
+ENV PATH="$POETRY_HOME/bin:$PATH"
+# the container is the env
+ENV POETRY_VIRTUALENVS_CREATE=false
+RUN curl -sSL https://install.python-poetry.org | python3 -
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files first for cache efficiency
+COPY pyproject.toml poetry.lock* ./
+RUN poetry install --no-root --with dev
+
+# Now copy the full project
+COPY . .
+
+CMD ["poetry", "run", "pytest"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+---
+# docker-compose.yml
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: sql_artifacts
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_URL: postgres://dev:dev@db:5432/sql_artifacts
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+    command: sleep infinity
+volumes:
+  pgdata:


### PR DESCRIPTION
This PR introduces a containerized development and testing environment using Docker and Docker Compose.

### What's Included
- **Dockerfile**:
  - Based on `python:3.13-slim`
  - Installs Poetry, PostgreSQL client, and build tools
  - Disables virtualenvs to treat the container as the runtime environment
  - Installs all project dependencies with `--with dev`

- **docker-compose.yaml**:
  - Defines a `db` service using `postgres:15` with predefined credentials
  - Defines a `dev` service that builds from the Dockerfile
  - Mounts the current project directory to `/app` in the container
  - Uses a persistent named volume `pgdata` for database state
  - Sets `sleep infinity` as the container's default command for interactive development

### Purpose
This setup standardizes the local development environment and provides an isolated, reproducible setup for:
- Writing and testing SQL artifacts
- Running integration tests against a real PostgreSQL service
- Using the same stack in CI workflows

### Next Steps
- Add Makefile helpers for common Docker workflows
- Integrate with GitHub Actions for local/CI parity

- Adds Dockerfile to define a Python 3.13-based environment with Poetry and PostgreSQL client
- Adds docker-compose.yaml to orchestrate a dev container and PostgreSQL service
- Configures Poetry to install dependencies system-wide inside the container
- Supports local and CI usage with persistent volume for Postgres and shared source mounting
- `dev` container runs in idle mode (`sleep infinity`) for interactive use
